### PR TITLE
index: Rename "Slicer4" to "Slicer"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 slicer_download_stats
 ======================
 
-Slicer4 download statistics (see http://download.slicer.org/download-stats)
+Slicer download statistics (see http://download.slicer.org/download-stats)

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 
 <html>
 <head>
-  <title>Slicer4 download stats</title>
+  <title>Slicer download stats</title>
 
   <link rel="stylesheet" type="text/css" href="bower_components/dc.js/dc.css" />
   <link rel="stylesheet" type="text/css" href="bower_components/bootstrap-daterangepicker/daterangepicker.css" />
@@ -81,7 +81,7 @@
         <a href="https://www.slicer.org/"><img src="img/slicer-logo-79x80.png"></img></a>
       </div>
       <div class="col-md-9 col-sm-8 col-xs-8">
-       <h1>Slicer4 download stats</h1>
+       <h1>Slicer download stats</h1>
       </div>
 
       <div class="col-md-2 col-sm-2 col-xs-4">


### PR DESCRIPTION
Following the start of Slicer 5 development, the "Slicer download stats"
website is not specific to Slicer 4 anymore.

See Slicer/Slicer@443372b68 (ENH: Slicer 5.0.0) and https://github.com/Slicer/Slicer/issues/6337